### PR TITLE
Add looser version parsing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: '2'
 jobs:
   integration-test:
     machine:
-      image: circleci/classic:201711-01
+      image: ubuntu-1604:202007-01
     working_directory: ~/code
     steps:
       - checkout
@@ -11,7 +11,7 @@ jobs:
           working_directory: ~/code
           command: |
             sudo apt update && sudo apt install -yq python3-pip
-            pyenv global 3.6.2
+            pyenv global 3.8.3
             pip install -r integration-test/test_requirements.txt
       - run:
           name: Run Integration Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
           working_directory: ~/code
           command: |
             sudo apt update && sudo apt install -yq python3-pip
-            pyenv global 3.5.2
+            pyenv global 3.6.2
             pip install -r integration-test/test_requirements.txt
       - run:
           name: Run Integration Tests

--- a/consul_plugin.py
+++ b/consul_plugin.py
@@ -8,6 +8,7 @@ import time
 from functools import reduce
 
 from six.moves import urllib
+from distutils.version import LooseVersion as V
 
 import collectd
 import urllib_ssl_handler
@@ -924,12 +925,8 @@ class ConsulAgent(object):
         self.metrics_enabled = self.check_metrics_endpoint_available()
 
     def check_metrics_endpoint_available(self):
-        # /agent/metrics endpoint is available from version 0.9.1
-        major, minor, revision = [int(x) for x in self.config.get("Config", {}).get("Version", "0.0.0").split(".")]
-
-        if (major == 0 and minor == 9 and revision >= 1) or major > 0:
-            return True
-        return False
+        version = self.config.get("Config", {}).get("Version", "0.0.0")
+        return V(version) >= V('0.9.1')
 
     def get_local_config(self):
         return self._send_request(self.local_config_url)

--- a/integration-test/test_requirements.txt
+++ b/integration-test/test_requirements.txt
@@ -2,6 +2,6 @@ mock
 flake8
 six
 
-pytest==3.6.0
+pytest==3.10.0
 pytest-xdist==1.22.2
 https://github.com/signalfx/collectd-common/archive/testing-v0.0.2.zip#subdirectory=testing

--- a/test/test_consul_agent.py
+++ b/test/test_consul_agent.py
@@ -150,6 +150,12 @@ class ConsulAgentTest(unittest.TestCase):
 
         self.agent.config["Config"]["Version"] = "0.9.0"
         self.assertFalse(self.agent.check_metrics_endpoint_available())
+        
+        self.agent.config["Config"]["Version"] = "1.8.1+ent"
+        self.assertTrue(self.agent.check_metrics_endpoint_available())
+
+        self.agent.config["Config"]["Version"] = "0.8.1+ent"
+        self.assertFalse(self.agent.check_metrics_endpoint_available())
 
     @mock.patch("consul_plugin.ConsulAgent.get_dc_leader", return_value=sample_response("/status/leader"))
     def test_is_leader(self, mock_call):


### PR DESCRIPTION
Works for alphanumeric strings, such as `1.8.4+ent`

Same thing we use for parsing mongodb versions - https://github.com/signalfx/collectd-mongodb/blob/master/mongodb.py#L121-L124